### PR TITLE
fixed oregen

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -43,6 +43,7 @@ minetest.register_node("wow:block", {
         groups = {cracky = 3},
         drop = "wow:coin",
         is_ground_content = true,
+        light_source = 5,
 })
                                         
 -- Set necessary privileges for shop

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,6 @@
- author = Polymechanos
+author = Polymechanos
 description = wownero to the mooooooooon!!!
 release = 1
 title = wownero
 name = wow
+depends = default


### PR DESCRIPTION
This fixes oregen. It also makes the wow:block glow so you can more easily see it when exploring.
At the current mapgen settings it is VERY common.